### PR TITLE
Pull request to add search term to the results page title

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,7 +3,7 @@
     <link rel="stylesheet/less" type="text/css" href="/lib/bootstrap.less">
     <script src="/js/less-1.1.3.min.js" type="text/javascript"></script>
     <link rel="search" type="application/opensearchdescription+xml" title="Oldskool" href="/opensearch.xml" />
-    <title>Oldskool</title>
+    <title><%= params[:q] == nil ? "" : h(params[:q]) %> - Oldskool</title>
   </head>
   <body style="padding-top: 80px;">
     <div class="topbar" data-dropdown="dropdown" >


### PR DESCRIPTION
Hi, I set up oldskool for myself this weekend and it's great - the only thing I've changed is adding the search term to the <title> tag of the results page so that when I have lots of search results tabs open I can distinguish between them. It's such a tiny change I didn't bother with a branch, but I thought you might be interested in it anyway.

Great job on oldskool! I'm going to have a look at adding a plugin for chiliproject - easy searching of our issues & wiki at work would be very handy :-)
